### PR TITLE
Anchor allowed_tlds match to whole TLD labels

### DIFF
--- a/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
+++ b/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
@@ -46,7 +46,17 @@ class HomographicSpoofing::Detector::Rule::Idn::ScriptConfusable < HomographicSp
       [ /\p{Mymr}/, /[ခဂငထပဝ၀၂ၔၜ\u1090\u1091\u1095\u1096\u1097]/, /[a-z]+\.mm/ ],
       # # Thai
       [ /\p{Thai}/, /[ทนบพรหเแ๐ดลปฟม]/, /th/ ]
-    ].map { Confusable.new(*_1) }
+    ]
+    # Anchor each allowed-TLD pattern so it only matches whole trailing labels
+    # of the TLD, never a substring of one. Unanchored, `/ru/` matched `.guru`,
+    # `/su/` matched `.surf`, `/by/` matched `.baby`/`.rugby`, etc., silently
+    # disabling single-script confusable detection on those TLDs. The
+    # `(?:\A|\.)…\z` boundary keeps multi-label public suffixes working —
+    # `co.th` still matches `/th/`, `com.mm` still matches `/[a-z]+\.mm/`.
+    .map do |script, latin_lookalike, allowed_tlds|
+      anchored_tlds = allowed_tlds && /(?:\A|\.)(?:#{allowed_tlds.source})\z/
+      Confusable.new script, latin_lookalike, anchored_tlds
+    end
 
     def is_script_confusable_allowed_for_tld?(confusable)
       tld_contains_any_letter_from_script?(confusable.script) ||

--- a/test/detector/idn_test.rb
+++ b/test/detector/idn_test.rb
@@ -200,6 +200,29 @@ class HomographicSpoofing::Detector::IdnTest < ActiveSupport::TestCase
     assert_attack("\u0300abc.jp")
   end
 
+  test "Whole script confusable is not allowed on TLDs that merely contain an allowed ccTLD as a substring" do
+    # раураӏ = paypal spoofed with Cyrillic look-alikes.
+    assert_attack("раураӏ.com", reason: "script_confusable")
+    assert_safe("раураӏ.ru")   # legit: single-label ccTLD .ru is allowed for Cyrillic
+    # These TLDs only *contain* an allowed Cyrillic ccTLD as a substring and
+    # must not disable detection: .guru⊃ru, .surf⊃su, .baby/.rugby⊃by.
+    assert_attack("раураӏ.guru", reason: "script_confusable")
+    assert_attack("раураӏ.surf", reason: "script_confusable")
+    assert_attack("раураӏ.baby", reason: "script_confusable")
+    assert_attack("раураӏ.rugby", reason: "script_confusable")
+    # Cross-script substring collisions: .net⊃et (Ethiopic), .email⊃il (Hebrew).
+    assert_attack("ሠዐዐፐ.net", reason: "script_confusable")
+    assert_attack("חסד.email", reason: "script_confusable")
+    # The allowed ccTLD must be a trailing label, not any interior label: .il is
+    # Israel's registry, but k12.il.us is a US suffix and must stay guarded.
+    assert_attack("חסד.k12.il.us", reason: "script_confusable")
+    # Multi-label public suffixes stay allowed for their script: .th matches the
+    # trailing label of co.th, Myanmar's expression matches all of net.mm.
+    assert_safe("ทนบพรห.co.th")
+    assert_safe("ทนบพรห.th")
+    assert_safe("င၀ဂခဂ.net.mm")
+  end
+
   test "Whole script confusable" do
     # Armenian
     assert_attack("ոսւօ.com")


### PR DESCRIPTION
## Problem

`ScriptConfusable` decides whether a single-script IDN label is allowed on a given TLD by matching the script's list of legitimate ccTLDs against `PublicSuffix#tld`. The match used an **unanchored** `Regexp#match?`, so any TLD that merely *contained* an allowed ccTLD as a substring was treated as allowed — which silently disabled confusable detection there.

Because `MixedScripts` bails on single-script labels, `ScriptConfusable` is the *only* guard for them, so a wrong "allowed" here returns not-spoofed for an outright homograph.

Substring collisions that bypassed detection:

| spoof label | TLD | allowed ccTLD contained |
|---|---|---|
| `раураӏ` (paypal, Cyrillic) | `.guru` | `ru` |
| `раураӏ` | `.surf` | `su` |
| `раураӏ` | `.baby`, `.rugby` | `by` |
| Ethiopic homograph | `.net` | `et` |
| Hebrew homograph | `.email` | `il` |

Differential proof: `раураӏ.com` is flagged, but `раураӏ.guru` was not.

## Root cause

The unanchored match has been present since the initial port (`43bde9bc4dcf45a54222d2ad5ed789aa3da68c50`):

```ruby
confusable.allowed_tlds&.match?(tld)   # /ru/ matches "guru"
```

## Fix

Anchor each stored `allowed_tlds` pattern to whole trailing labels of the TLD with a `(?:\A|\.)…\z` boundary:

```ruby
anchored_tlds = allowed_tlds && /(?:\A|\.)(?:#{allowed_tlds.source})\z/
```

- Rejects substring collisions (`guru`, `surf`, `baby`, `rugby`, `net`, `email` no longer match).
- Keeps multi-label public suffixes working: `co.th` still matches `th`, `com.mm`/`net.mm` still match Myanmar's `[a-z]+\.mm`.
- Requires the allowed ccTLD to be the **final** label, so an interior collision such as `k12.il.us` (a US suffix, not Israel's `.il` registry) stays guarded.

No false-positive regression: legitimate single- and multi-label ccTLDs (`.ru`, `.co.th`, `.net.mm`) remain allowed for their script; the existing "Whole script confusable" suite is unchanged and still green.

## Test

New regression test pins the substring collisions, the trailing-label boundary (`k12.il.us` guarded), and the multi-label suffixes that must remain allowed (`co.th`, `net.mm`). It fails before this change (`раураӏ.guru` undetected) and passes after. Full suite: 39 runs, 0 failures.

## Verification

- Reproduced the bypass and confirmed the fix via differential runs and the new test (fails-before / passes-after).
- Adversarial review confirmed the anchoring is sound with no substring bypass and no false-positive regression on multi-label public suffixes.
- Content scanned for credentials/PII — none.

Note: releasing the patched gem (`bin/release`) and bumping the pin in the consuming app is a separate follow-up.