### PR TITLE
Scan each domain label independently for script confusables

### DIFF
--- a/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
+++ b/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
@@ -1,15 +1,25 @@
 # 9. and 10. of Google Chrome IDN policy See http://unicode.org/reports/tr39/#Confusable_Detection
 class HomographicSpoofing::Detector::Rule::Idn::ScriptConfusable < HomographicSpoofing::Detector::Rule::Idn::Base
   def attack_detected?
-    SCRIPT_CONFUSABLES.any? do |confusable|
-      confusable_chars = label.scan(confusable.script)
-      confusable_chars.present? &&
-        confusable_chars.all? { confusable.latin_lookalike.match?(_1) } &&
-        !is_script_confusable_allowed_for_tld?(confusable)
+    # Scan each domain label independently: a confusable label anywhere in the
+    # chain is an attack even when benign sibling labels — including same-script
+    # ones without a Latin look-alike — would make the *combined* string pass
+    # the all-look-alike check below.
+    sublabels.any? do |sublabel|
+      SCRIPT_CONFUSABLES.any? do |confusable|
+        confusable_chars = sublabel.scan(confusable.script)
+        confusable_chars.present? &&
+          confusable_chars.all? { confusable.latin_lookalike.match?(_1) } &&
+          !is_script_confusable_allowed_for_tld?(confusable)
+      end
     end
   end
 
   private
+    def sublabels
+      label.split(".")
+    end
+
     Confusable = Struct.new(:script, :latin_lookalike, :allowed_tlds)
     SCRIPT_CONFUSABLES = [
       # Armenian

--- a/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
+++ b/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
@@ -1,10 +1,9 @@
 # 9. and 10. of Google Chrome IDN policy See http://unicode.org/reports/tr39/#Confusable_Detection
 class HomographicSpoofing::Detector::Rule::Idn::ScriptConfusable < HomographicSpoofing::Detector::Rule::Idn::Base
   def attack_detected?
-    # Scan each domain label independently: a confusable label anywhere in the
-    # chain is an attack even when benign sibling labels — including same-script
-    # ones without a Latin look-alike — would make the *combined* string pass
-    # the all-look-alike check below.
+    # Per label, not over the whole subdomain chain: `all?` over the merged
+    # chain lets one non-look-alike character in a benign sibling label suppress
+    # detection of an adjacent all-look-alike (confusable) label.
     sublabels.any? do |sublabel|
       SCRIPT_CONFUSABLES.any? do |confusable|
         confusable_chars = sublabel.scan(confusable.script)

--- a/test/detector/idn_test.rb
+++ b/test/detector/idn_test.rb
@@ -223,6 +223,39 @@ class HomographicSpoofing::Detector::IdnTest < ActiveSupport::TestCase
     assert_safe("င၀ဂခဂ.net.mm")
   end
 
+  test "Script confusable is detected per-label, not on the whole subdomain chain" do
+    # A single confusable label must be caught even when benign sibling labels
+    # elsewhere in the chain would make the *combined* string fail the
+    # all-look-alike check. раураӏ = paypal spoofed with Cyrillic look-alikes;
+    # музей (museum in Russian) is same-script Cyrillic but has characters
+    # without a Latin look-alike, so scanning the chain as one label hid it.
+    assert_attack("раураӏ.музей.example.com", reason: "script_confusable")
+    assert_attack("музей.раураӏ.example.com", reason: "script_confusable")
+    # TLD-independent: the .com allow-list plays no part; any TLD is affected.
+    assert_attack("раураӏ.музей.example.net", reason: "script_confusable")
+    assert_attack("раураӏ.музей.example.org", reason: "script_confusable")
+    # Benign ASCII sibling labels must not mask the confusable one either.
+    assert_attack("shop.ѕсоре.example.io", reason: "script_confusable")
+    assert_attack("ѕсоре.www.example.co.uk", reason: "script_confusable")
+    # Confusable buried several labels deep in a longer chain.
+    assert_attack("a.раураӏ.b.c.example.com", reason: "script_confusable")
+
+    # Legitimate multi-label domains must not regress into false positives.
+    # Per-label scanning still honours #72's allowed-TLD anchoring: an all
+    # look-alike Cyrillic label on a Cyrillic-allowed ccTLD stays safe, even as
+    # a subdomain.
+    assert_safe("рау.почта.ru")
+    assert_safe("рау.example.москва")
+    # Same-script but non-look-alike labels remain safe regardless of siblings.
+    assert_safe("почта.музей.example.ru")
+    # Plain ASCII / punycode subdomains carry no confusable script.
+    assert_safe("www.example.com")
+    assert_safe("login.accounts.example.co.uk")
+    assert_safe("xn--80a1acny.www.example.com")
+    # Legitimate Han/Kana subdomain chains stay highly-restrictive and safe.
+    assert_safe("おかが.キギク.co.jp")
+  end
+
   test "Whole script confusable" do
     # Armenian
     assert_attack("ոսւօ.com")


### PR DESCRIPTION
## Problem

`ScriptConfusable` scans the entire subdomain chain as a single combined
label. `HomographicSpoofing::Detector::Idn` builds one rule context per
registrable-domain part, and for subdomains that context's `label` is the
whole `trd` (e.g. `sub.a.example.com` → `"sub.a"`). The rule then scans that
combined string with `label.scan(confusable.script)` and requires **every**
matched character to be a Latin look-alike.

That "all look-alike" requirement is per-*chain*, not per-*label*, so a single
benign sibling label anywhere in the chain disables confusable detection for
the whole chain — on any TLD, `.com` included. A same-script label that
contains characters without a Latin look-alike is enough to dilute the scan.

### Example

```ruby
# Cyrillic "раураӏ" spoofs the Latin "paypal".
HomographicSpoofing::Detector::Idn.detected?("раураӏ.example.com")
# => true  (correctly flagged)

HomographicSpoofing::Detector::Idn.detected?("раураӏ.музей.example.com")
# => false (BUG — undetected)
```

The benign same-script label `музей` (Russian for "museum") carries Cyrillic
characters with no Latin look-alike. Combined with `раураӏ` into one scanned
string, the `all?` look-alike check fails and detection is silently skipped —
even though `раураӏ` on its own is a clear spoof.

## Fix

Scan each dot-separated domain label independently. A confusable label anywhere
in the chain is flagged regardless of benign sibling labels.

The allowed-TLD anchoring is untouched: the allow-list still keys off the
trailing TLD label per confusable script, so legitimate same-script labels on
their own ccTLD (e.g. `рау.почта.ru`) remain safe, and punycode / ASCII
subdomains carry no confusable script.

## Tests

Adds coverage for confusable labels buried among benign siblings across several
TLDs (fails before this change, passes after), plus false-positive guards for
legitimate multi-label and IDN domains (allowed-ccTLD subdomains, punycode
labels, `co.th`-style suffixes, Han/Kana chains). Full suite green.
