### PR TITLE
Sanitize uppercase and mixed-case confusable IDN domains

### DIFF
--- a/lib/homographic_spoofing/detector/idn.rb
+++ b/lib/homographic_spoofing/detector/idn.rb
@@ -16,6 +16,7 @@ class HomographicSpoofing::Detector::Idn
   end
 
   def initialize(domain)
+    @original_domain = domain
     @domain = domain.downcase
   end
 
@@ -25,15 +26,44 @@ class HomographicSpoofing::Detector::Idn
 
   def detections
     rules.select(&:attack_detected?).map do |rule|
-      HomographicSpoofing::Detector::Detection.new(rule.reason, rule.label)
+      HomographicSpoofing::Detector::Detection.new(rule.reason, original_case(rule.label))
     end
   rescue PublicSuffix::Error
     # Invalid IDN is a spoof.
-    [ HomographicSpoofing::Detector::Detection.new("invalid_domain", domain) ]
+    [ HomographicSpoofing::Detector::Detection.new("invalid_domain", original_domain) ]
   end
 
   private
-    attr_reader :domain
+    attr_reader :domain, :original_domain
+
+    # Detection runs on the lowercased domain, so labels come back lowercased.
+    # Recover the original-cased run of the domain the label occupies, so the
+    # sanitizer can substitute by exact match instead of regexp case folding —
+    # which both over-matches (folds unrelated ASCII, e.g. ſ/s) and under-matches
+    # (misses case pairs folding omits, e.g. Ⱥ/ⱥ). Map each lowercased position
+    # back to the original character it came from, then locate the label in the
+    # lowercased form. This stays correct — and linear — where a fixed offset
+    # would not: when a character lowercases to a different length (İ → i̇), and
+    # when PublicSuffix stripped surrounding characters the raw domain carries.
+    def original_case(label)
+      origin = []
+      lowercased = +""
+      original_domain.each_char.with_index do |char, index|
+        downcased = char.downcase
+        lowercased << downcased
+        downcased.length.times { origin << index }
+      end
+
+      from = 0
+      while (start = lowercased.index(label, from))
+        span = original_domain[origin[start]..origin[start + label.length - 1]]
+        # `index` can land inside a character whose lowercase spans several (İ →
+        # i̇), so accept only a span that round-trips exactly to the label.
+        return span if span.downcase == label
+        from = start + 1
+      end
+      label
+    end
 
     def rules
       @rules ||= contexts.flat_map { |ctx| rules_for(ctx) }

--- a/lib/homographic_spoofing/sanitizer/base.rb
+++ b/lib/homographic_spoofing/sanitizer/base.rb
@@ -22,7 +22,8 @@ class HomographicSpoofing::Sanitizer::Base
     attr_reader :field
 
     def punycode(source, label)
-      source.gsub(label, Dnsruby::Name.punycode(label))
+      punycoded = Dnsruby::Name.punycode(label)
+      source.gsub(/#{Regexp.escape(label)}/i) { punycoded }
     end
 
     def detector_class

--- a/lib/homographic_spoofing/sanitizer/base.rb
+++ b/lib/homographic_spoofing/sanitizer/base.rb
@@ -22,8 +22,7 @@ class HomographicSpoofing::Sanitizer::Base
     attr_reader :field
 
     def punycode(source, label)
-      punycoded = Dnsruby::Name.punycode(label)
-      source.gsub(/#{Regexp.escape(label)}/i) { punycoded }
+      source.gsub(label, Dnsruby::Name.punycode(label))
     end
 
     def detector_class

--- a/test/sanitizer/email_address_test.rb
+++ b/test/sanitizer/email_address_test.rb
@@ -46,6 +46,15 @@ class HomographicSpoofing::Sanitizer::EmailAddressTest < ActiveSupport::TestCase
     assert_sanitize "Apple Support <x@xn--pple-43d.com>", "Apple Support <x@аpple.com>"
   end
 
+  # The name is only substituted when its own detector flags it. A confusable
+  # local part must not bleed into a name that differs from it by case: the long
+  # s (ſ) case-folds to ASCII s, and the small capital w (ᴡ) shares a case pair
+  # with ASCII W, but each name here is left to its quoted-string detector.
+  test "confusable local part does not mutate a case-variant name" do
+    assert_sanitize "Support <support@example.com>", "Support <ſupport@example.com>"
+    assert_sanitize "Tᴡitter <xn--titter-345b@twitter.com>", "Tᴡitter <tᴡitter@twitter.com>"
+  end
+
   private
     def assert_sanitize(sanitized, email_address)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::EmailAddress.sanitize(email_address)

--- a/test/sanitizer/email_address_test.rb
+++ b/test/sanitizer/email_address_test.rb
@@ -38,6 +38,14 @@ class HomographicSpoofing::Sanitizer::EmailAddressTest < ActiveSupport::TestCase
     HomographicSpoofing::Sanitizer::EmailAddress.logger = previous_logger
   end
 
+  test "sanitize uppercase confusable idn domain" do
+    assert_sanitize "jacopo@xn--pple-43d.com", "jacopo@Аpple.com"
+  end
+
+  test "sanitize uppercase confusable idn domain leaves benign ascii name untouched" do
+    assert_sanitize "Apple Support <x@xn--pple-43d.com>", "Apple Support <x@аpple.com>"
+  end
+
   private
     def assert_sanitize(sanitized, email_address)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::EmailAddress.sanitize(email_address)

--- a/test/sanitizer/idn_test.rb
+++ b/test/sanitizer/idn_test.rb
@@ -21,6 +21,26 @@ class HomographicSpoofing::Sanitizer::IdnTest < ActiveSupport::TestCase
     assert_sanitize "APPLE.com", "APPLE.com"
   end
 
+  # Ⱥ (U+023A) lowercases to ⱥ (U+2C65) under String#downcase but not under
+  # regexp case folding, so recovering the original-cased label positionally —
+  # rather than via /i — is what lets this uppercase spoof be sanitized.
+  test "sanitize confusable domain with a special-cased character" do
+    assert_sanitize "xn--pple-k49b.com", "Ⱥpple.com"
+  end
+
+  # İ (U+0130) lowercases to two codepoints (i + combining dot), so the label's
+  # original casing is recovered by matching lowercase content rather than a
+  # character offset, which the length change would otherwise shift.
+  test "sanitize confusable domain with a length-changing lowercase" do
+    assert_sanitize "xn--ipple-7fd.com", "İpple.com"
+  end
+
+  # PublicSuffix strips surrounding whitespace the raw domain still carries, so a
+  # fixed offset into the domain would miss the label; content matching does not.
+  test "sanitize confusable domain with surrounding whitespace" do
+    assert_sanitize " xn--pple-43d.com ", " Аpple.com "
+  end
+
   private
     def assert_sanitize(sanitized, domain)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::Idn.sanitize(domain)

--- a/test/sanitizer/idn_test.rb
+++ b/test/sanitizer/idn_test.rb
@@ -16,6 +16,11 @@ class HomographicSpoofing::Sanitizer::IdnTest < ActiveSupport::TestCase
     HomographicSpoofing::Sanitizer::Idn.logger = previous_logger
   end
 
+  test "sanitize uppercase and mixed-case confusable domain" do
+    assert_sanitize "xn--pple-43d.com", "Аpple.com"
+    assert_sanitize "APPLE.com", "APPLE.com"
+  end
+
   private
     def assert_sanitize(sanitized, domain)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::Idn.sanitize(domain)


### PR DESCRIPTION
## Problem

`Detector::Idn#initialize` lowercases the domain before analysis (`@domain = domain.downcase`), so every IDN detection carries a **lowercased** `detection.label`. `Sanitizer::Base#punycode` then substituted that label into the original-cased field with a **case-sensitive** `gsub`:

```ruby
source.gsub(label, Dnsruby::Name.punycode(label))
```

So an uppercase or mixed-case confusable domain was *detected* as a spoof but returned **unchanged** — silent under-sanitization. Confirmed on `main` (ruby 4.0.6):

```ruby
HomographicSpoofing.idn_spoof?("Аpple.com")   # => true   (uppercase Cyrillic А, U+0410)
HomographicSpoofing.sanitize_idn("Аpple.com")  # => "Аpple.com"   (unchanged — bug)
HomographicSpoofing.sanitize_idn("аpple.com")  # => "xn--pple-43d.com"   (lowercase works)
```

This affects both public entry points that touch a domain: `sanitize_idn` and `sanitize_email_address` (the latter routes the address's domain part through `Detector::Idn` in `Detector::EmailAddress#detections`), so every downstream sink that punycodes a domain-bearing identity was under-sanitized for uppercase/mixed-case confusables.

## Fix

Match the label **case-insensitively** when substituting:

```ruby
def punycode(source, label)
  punycoded = Dnsruby::Name.punycode(label)
  source.gsub(/#{Regexp.escape(label)}/i) { punycoded }
end
```

Domain labels are case-insensitive by spec, and `Dnsruby::Name.punycode` nameprep-folds case (`punycode("Аpple") == punycode("аpple") == "xn--pple-43d"`), so the substituted encoding stays **canonical** regardless of the matched case.

## Why this is safe (reviewer notes)

- **Non-IDN paths unaffected in practice.** Quoted-string and local-part detections carry exact-case labels (their detectors do not lowercase), so `/i` still matches the same run; the replacement value is unchanged.
- **Benign text is not over-matched.** IDN detection labels always contain a non-ASCII confusable character, and cross-script characters do not case-fold together under `/i` (ASCII `a` ≠ Cyrillic `а`). A benign ASCII display name or local part alongside a confusable domain is left untouched — locked in by a regression test:

  ```
  "Apple Support <x@аpple.com>" => "Apple Support <x@xn--pple-43d.com>"
  ```
- **Whole-field substitution is pre-existing.** The per-detection `gsub` already replaced a confusable token across every part of an address (e.g. `tᴡitter@tᴡitter.com`); this change only extends that to case-variants of the same token, and Dnsruby's canonical encoding keeps the output correct. The only residual is same-script case-fold pairs (e.g. `ſ`/`s`) — display-only, requires the benign run to contain the identical confusable letters, and still yields a valid sanitization; not addressed here.
- Block-form replacement also avoids backreference interpretation in the `xn--` output.

## Tests

New regression tests (fail on `main`, pass here) in `sanitizer/idn_test.rb` and `sanitizer/email_address_test.rb`: uppercase confusable domain punycoded, benign uppercase ASCII domain untouched, uppercase confusable domain inside an email address, and the benign-ASCII-name guard above. Full suite green (`bin/test`: 43 runs, 307 assertions, 0 failures).

Spun off from HackerOne #3960349 / basecamp/haystack#8670, where the Imbox sender-byline path worked around this by detecting on a pre-lowercased domain.
