### PR TITLE
Apply mixed-script rules per label, not over the whole subdomain chain

### DIFF
--- a/lib/homographic_spoofing/detector/idn.rb
+++ b/lib/homographic_spoofing/detector/idn.rb
@@ -85,9 +85,19 @@ class HomographicSpoofing::Detector::Idn
     end
 
     def contexts
-      [ public_suffix.sld, public_suffix.trd ].compact.map do |label|
+      labels.map do |label|
         HomographicSpoofing::Detector::Rule::Idn::Context.new(label: label, tld: public_suffix.tld)
       end
+    end
+
+    # `trd` is the full subdomain chain ("a.b" in a.b.example.com). Split it on
+    # the same dot the renderer draws so each rule sees one real label rather
+    # than a chain. The mixed-script, confusable and digit rules are per-label:
+    # a combined chain both hides attacks (a benign sibling dilutes an
+    # all-look-alike label out of detection) and invents them (two single-script
+    # sibling labels look "mixed" together though each is safe on its own).
+    def labels
+      [ public_suffix.sld, *public_suffix.trd&.split(".") ].compact.reject(&:empty?)
     end
 
     def public_suffix

--- a/lib/homographic_spoofing/detector/idn.rb
+++ b/lib/homographic_spoofing/detector/idn.rb
@@ -57,18 +57,38 @@ class HomographicSpoofing::Detector::Idn
       seen = 0
       from = 0
       while (start = lowercased.index(label, from))
-        span = original_domain[origin[start]..origin[start + label.length - 1]]
-        # `index` can land inside a character whose lowercase spans several (İ →
-        # i̇), so accept only a span that round-trips exactly to the label. Count
-        # valid matches so a label repeated in the domain resolves to the casing
-        # of its own occurrence rather than always the first.
-        if span.downcase == label
-          return span if seen == occurrence
-          seen += 1
+        finish = start + label.length
+        # Match only whole labels, at a "." or edge boundary — otherwise a short
+        # label (e.g. "з") would resolve to its appearance *inside* a longer
+        # sibling ("магаЗин"), corrupting the sibling and leaving the real label
+        # untouched. `index` can also land inside a character whose lowercase
+        # spans several (İ → i̇), so accept only a span that round-trips exactly.
+        # Count valid matches so a repeated label resolves to the casing of its
+        # own occurrence rather than always the first.
+        if label_start?(lowercased, start) && label_end?(lowercased, finish)
+          span = original_domain[origin[start]..origin[finish - 1]]
+          if span.downcase == label
+            return span if seen == occurrence
+            seen += 1
+          end
         end
         from = start + 1
       end
       label
+    end
+
+    # A domain label is bounded by "." separators, the string edges, or the
+    # surrounding whitespace PublicSuffix strips from the raw domain.
+    def label_start?(string, index)
+      index.zero? || label_separator?(string[index - 1])
+    end
+
+    def label_end?(string, index)
+      index >= string.length || label_separator?(string[index])
+    end
+
+    def label_separator?(char)
+      char == "." || char =~ /\s/
     end
 
     def rules

--- a/lib/homographic_spoofing/detector/idn.rb
+++ b/lib/homographic_spoofing/detector/idn.rb
@@ -26,7 +26,7 @@ class HomographicSpoofing::Detector::Idn
 
   def detections
     rules.select(&:attack_detected?).map do |rule|
-      HomographicSpoofing::Detector::Detection.new(rule.reason, original_case(rule.label))
+      HomographicSpoofing::Detector::Detection.new(rule.reason, original_case(rule.label, rule.occurrence))
     end
   rescue PublicSuffix::Error
     # Invalid IDN is a spoof.
@@ -45,7 +45,7 @@ class HomographicSpoofing::Detector::Idn
     # lowercased form. This stays correct — and linear — where a fixed offset
     # would not: when a character lowercases to a different length (İ → i̇), and
     # when PublicSuffix stripped surrounding characters the raw domain carries.
-    def original_case(label)
+    def original_case(label, occurrence = 0)
       origin = []
       lowercased = +""
       original_domain.each_char.with_index do |char, index|
@@ -54,12 +54,18 @@ class HomographicSpoofing::Detector::Idn
         downcased.length.times { origin << index }
       end
 
+      seen = 0
       from = 0
       while (start = lowercased.index(label, from))
         span = original_domain[origin[start]..origin[start + label.length - 1]]
         # `index` can land inside a character whose lowercase spans several (İ →
-        # i̇), so accept only a span that round-trips exactly to the label.
-        return span if span.downcase == label
+        # i̇), so accept only a span that round-trips exactly to the label. Count
+        # valid matches so a label repeated in the domain resolves to the casing
+        # of its own occurrence rather than always the first.
+        if span.downcase == label
+          return span if seen == occurrence
+          seen += 1
+        end
         from = start + 1
       end
       label
@@ -85,8 +91,8 @@ class HomographicSpoofing::Detector::Idn
     end
 
     def contexts
-      labels.map do |label|
-        HomographicSpoofing::Detector::Rule::Idn::Context.new(label: label, tld: public_suffix.tld)
+      labels.map do |label, occurrence|
+        HomographicSpoofing::Detector::Rule::Idn::Context.new(label:, tld: public_suffix.tld, occurrence:)
       end
     end
 
@@ -96,8 +102,18 @@ class HomographicSpoofing::Detector::Idn
     # a combined chain both hides attacks (a benign sibling dilutes an
     # all-look-alike label out of detection) and invents them (two single-script
     # sibling labels look "mixed" together though each is safe on its own).
+    #
+    # Labels are kept in left-to-right domain order and paired with the index of
+    # their occurrence among identical labels, so a repeated label recovers the
+    # casing of its own position (see #original_case).
     def labels
-      [ public_suffix.sld, *public_suffix.trd&.split(".") ].compact.reject(&:empty?)
+      ordered = [ *public_suffix.trd&.split("."), public_suffix.sld ].compact.reject(&:empty?)
+      seen = Hash.new(0)
+      ordered.map do |label|
+        occurrence = seen[label]
+        seen[label] += 1
+        [ label, occurrence ]
+      end
     end
 
     def public_suffix

--- a/lib/homographic_spoofing/detector/rule/base.rb
+++ b/lib/homographic_spoofing/detector/rule/base.rb
@@ -1,5 +1,5 @@
 class HomographicSpoofing::Detector::Rule::Base
-  delegate :scripts, :label, :label_set, to: :@context
+  delegate :scripts, :label, :label_set, :occurrence, to: :@context
 
   def initialize(context)
     @context = context

--- a/lib/homographic_spoofing/detector/rule/context.rb
+++ b/lib/homographic_spoofing/detector/rule/context.rb
@@ -1,8 +1,12 @@
 class HomographicSpoofing::Detector::Rule::Context
-  attr_reader :label
+  attr_reader :label, :occurrence
 
-  def initialize(label:)
+  # `occurrence` disambiguates labels that repeat within a domain: it is the
+  # zero-based index of this label among identical labels, in left-to-right
+  # order, so the original casing of the right occurrence can be recovered.
+  def initialize(label:, occurrence: 0)
     @label = label
+    @occurrence = occurrence
   end
 
   SCRIPT_COMMON = "Common"

--- a/lib/homographic_spoofing/detector/rule/idn/context.rb
+++ b/lib/homographic_spoofing/detector/rule/idn/context.rb
@@ -1,8 +1,8 @@
 class HomographicSpoofing::Detector::Rule::Idn::Context < HomographicSpoofing::Detector::Rule::Context
   attr_reader :tld
 
-  def initialize(label:, tld:)
+  def initialize(label:, tld:, occurrence: 0)
     @tld = tld
-    super(label:)
+    super(label:, occurrence:)
   end
 end

--- a/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
+++ b/lib/homographic_spoofing/detector/rule/idn/script_confusable.rb
@@ -1,24 +1,15 @@
 # 9. and 10. of Google Chrome IDN policy See http://unicode.org/reports/tr39/#Confusable_Detection
 class HomographicSpoofing::Detector::Rule::Idn::ScriptConfusable < HomographicSpoofing::Detector::Rule::Idn::Base
   def attack_detected?
-    # Per label, not over the whole subdomain chain: `all?` over the merged
-    # chain lets one non-look-alike character in a benign sibling label suppress
-    # detection of an adjacent all-look-alike (confusable) label.
-    sublabels.any? do |sublabel|
-      SCRIPT_CONFUSABLES.any? do |confusable|
-        confusable_chars = sublabel.scan(confusable.script)
-        confusable_chars.present? &&
-          confusable_chars.all? { confusable.latin_lookalike.match?(_1) } &&
-          !is_script_confusable_allowed_for_tld?(confusable)
-      end
+    SCRIPT_CONFUSABLES.any? do |confusable|
+      confusable_chars = label.scan(confusable.script)
+      confusable_chars.present? &&
+        confusable_chars.all? { confusable.latin_lookalike.match?(_1) } &&
+        !is_script_confusable_allowed_for_tld?(confusable)
     end
   end
 
   private
-    def sublabels
-      label.split(".")
-    end
-
     Confusable = Struct.new(:script, :latin_lookalike, :allowed_tlds)
     SCRIPT_CONFUSABLES = [
       # Armenian

--- a/lib/homographic_spoofing/sanitizer/base.rb
+++ b/lib/homographic_spoofing/sanitizer/base.rb
@@ -21,8 +21,33 @@ class HomographicSpoofing::Sanitizer::Base
   private
     attr_reader :field
 
+    # Detections are per label. When the label is a complete component of the
+    # field — a whole domain label or local part, delimited by "." or "@" —
+    # punycode it as that component so an offending label is never replaced as a
+    # substring of a benign sibling (e.g. the Cyrillic digit-look-alike "з" that
+    # also sits inside "магазин"), and every occurrence is sanitized even when
+    # the same spoof repeats in different casing across labels. Components are
+    # matched with String#downcase, which — unlike regexp /i case folding — does
+    # not over-match unrelated case pairs (ſ/s, ᴡ/W). A label that is only a
+    # substring of a component (a display name carrying spaces) has no whole
+    # component to match and falls back to the exact substring replacement.
     def punycode(source, label)
-      source.gsub(label, Dnsruby::Name.punycode(label))
+      key = label.downcase
+      components = source.split(/([.@])/)
+      if components.any? { |component| component_label?(component) && component.strip.downcase == key }
+        components.map { |component| punycode_component(component, key) }.join
+      else
+        source.gsub(label) { Dnsruby::Name.punycode(label) }
+      end
+    end
+
+    def punycode_component(component, key)
+      content = component.strip
+      component_label?(component) && content.downcase == key ? component.sub(content, Dnsruby::Name.punycode(content)) : component
+    end
+
+    def component_label?(component)
+      component != "." && component != "@"
     end
 
     def detector_class

--- a/lib/homographic_spoofing/sanitizer/base.rb
+++ b/lib/homographic_spoofing/sanitizer/base.rb
@@ -25,29 +25,18 @@ class HomographicSpoofing::Sanitizer::Base
     # field — a whole domain label or local part, delimited by "." or "@" —
     # punycode it as that component so an offending label is never replaced as a
     # substring of a benign sibling (e.g. the Cyrillic digit-look-alike "з" that
-    # also sits inside "магазин"), and every occurrence is sanitized even when
-    # the same spoof repeats in different casing across labels. Components are
-    # matched with String#downcase, which — unlike regexp /i case folding — does
-    # not over-match unrelated case pairs (ſ/s, ᴡ/W). A label that is only a
-    # substring of a component (a display name carrying spaces) has no whole
-    # component to match and falls back to the exact substring replacement.
+    # also sits inside "магазин"). Matching is case-exact: the detector reports
+    # each label in the casing of its own position, so a spoof repeated in
+    # different casing yields a detection per occurrence, and a benign
+    # case-variant on the other side of the "@" is left alone. A label that is
+    # only a substring of a component (a display name carrying spaces) has no
+    # whole component to match and falls back to the exact substring replacement.
     def punycode(source, label)
-      key = label.downcase
-      components = source.split(/([.@])/)
-      if components.any? { |component| component_label?(component) && component.strip.downcase == key }
-        components.map { |component| punycode_component(component, key) }.join
+      if source.split(/[.@]/).any? { |component| component.strip == label }
+        source.split(/([.@])/).map { |component| component.strip == label ? component.sub(label, Dnsruby::Name.punycode(label)) : component }.join
       else
         source.gsub(label) { Dnsruby::Name.punycode(label) }
       end
-    end
-
-    def punycode_component(component, key)
-      content = component.strip
-      component_label?(component) && content.downcase == key ? component.sub(content, Dnsruby::Name.punycode(content)) : component
-    end
-
-    def component_label?(component)
-      component != "." && component != "@"
     end
 
     def detector_class

--- a/test/detector/idn_test.rb
+++ b/test/detector/idn_test.rb
@@ -321,6 +321,52 @@ class HomographicSpoofing::Detector::IdnTest < ActiveSupport::TestCase
     assert_attack("ძ4000.com")
   end
 
+  test "Mixed-script rules apply per label, not over the whole subdomain chain" do
+    # The `trd` is the full subdomain chain the renderer draws with dots between
+    # labels. Handing rules the combined chain both hides attacks and invents
+    # them; each of these was reclassified by scanning per label instead.
+
+    # Idn::Digits false negative: an all-look-alike digit label (Cyrillic "з"
+    # spoofing "3") was hidden when a benign same-script sibling ("мир") diluted
+    # the combined chain out of the "only digits or look-alikes" check.
+    assert_attack("мир.з.example.com", reason: "digits")
+    assert_attack("мир.з.example.net", reason: "digits")
+    assert_safe("мир.example.com")  # the benign sibling alone stays safe
+    assert_safe("123.example.com")  # plain ASCII-digit label is not a look-alike
+
+    # MixedScripts false positive: two single-script sibling labels (Latin
+    # "shop" + Cyrillic "москва") looked "mixed" only because the chain merged
+    # them; each label is single-script and benign.
+    assert_safe("shop.москва.example.com")
+    assert_safe("shop.москва.почта.example.com")
+    # Real within-label script mixing is still caught.
+    assert_attack("shop.pаypal.example.com", reason: "mixed_scripts")
+
+    # MixedDigits false positive: sibling labels using different digit systems
+    # (Arabic-Indic "٢" and Extended Arabic-Indic "۲"), each single-script on
+    # its own, tripped the cross-label digit-script count.
+    assert_safe("عربي٢.فارسي۲.example.com")
+    # Two digit systems within one label is still a real mixed-digits attack.
+    assert_attack("عربي٢۲.example.com", reason: "mixed_digits")
+
+    # ScriptSpecific false positive: a non-ASCII Latin label ("café") beside a
+    # non-Latin sibling ("мир") is not the "non-ASCII Latin mixing with a
+    # non-Latin script" the rule targets — that mixing happens within one label.
+    assert_safe("café.мир.example.com")
+
+    # Legitimate multi-label domains stay unflagged.
+    assert_safe("www.shop.example.co.uk")
+    assert_safe("login.accounts.example.co.uk")
+    # Confusable anchoring still honours the allowed ccTLD, even as a subdomain.
+    assert_safe("рау.почта.ru")
+    assert_safe("рау.example.москва")
+
+    # Degenerate labels must not raise or spuriously flag.
+    assert_safe("example.com.")     # trailing dot
+    assert_safe("a..b.example.com") # empty middle label
+    assert_safe("example.com")      # single registrable label, no subdomain
+  end
+
   test "PublixSuffix parsing errors" do
     assert_attack("  ", reason: "invalid_domain")
     assert_attack("example|.com", reason: "disallowed_characters")

--- a/test/sanitizer/email_address_test.rb
+++ b/test/sanitizer/email_address_test.rb
@@ -55,6 +55,18 @@ class HomographicSpoofing::Sanitizer::EmailAddressTest < ActiveSupport::TestCase
     assert_sanitize "Tᴡitter <xn--titter-345b@twitter.com>", "Tᴡitter <tᴡitter@twitter.com>"
   end
 
+  # Per-label domain detection punycodes the offending label as a whole
+  # component: a benign domain label that merely contains the same character
+  # (магазин contains the digit-look-alike "з") stays intact, and a spoofed
+  # label repeated in different casing is sanitized at every position.
+  test "sanitize a domain label that is a substring of a benign sibling label" do
+    assert_sanitize "jacopo@магазин.xn--g1a.example.com", "jacopo@магазин.з.example.com"
+  end
+
+  test "sanitize a confusable domain label repeated with different casing" do
+    assert_sanitize "jacopo@xn--pple-43d.xn--pple-43d.example.com", "jacopo@Аpple.аpple.example.com"
+  end
+
   private
     def assert_sanitize(sanitized, email_address)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::EmailAddress.sanitize(email_address)

--- a/test/sanitizer/email_address_test.rb
+++ b/test/sanitizer/email_address_test.rb
@@ -67,6 +67,14 @@ class HomographicSpoofing::Sanitizer::EmailAddressTest < ActiveSupport::TestCase
     assert_sanitize "jacopo@xn--pple-43d.xn--pple-43d.example.com", "jacopo@Аpple.аpple.example.com"
   end
 
+  # A benign local part that differs only by case from an offending domain label
+  # must not be punycoded: local parts can be case-sensitive, so rewriting the
+  # mailbox would change the recipient. Matching whole components case-exactly
+  # keeps the domain detection from bleeding across the "@".
+  test "confusable domain label does not mutate a case-variant local part" do
+    assert_sanitize "РАУ@xn--80a5ak.com", "РАУ@рау.com"
+  end
+
   private
     def assert_sanitize(sanitized, email_address)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::EmailAddress.sanitize(email_address)

--- a/test/sanitizer/idn_test.rb
+++ b/test/sanitizer/idn_test.rb
@@ -41,6 +41,20 @@ class HomographicSpoofing::Sanitizer::IdnTest < ActiveSupport::TestCase
     assert_sanitize " xn--pple-43d.com ", " Аpple.com "
   end
 
+  # Per-label detection means the offending label is punycoded as a whole
+  # component, not as a substring: a benign sibling that merely contains the
+  # same character (магазин contains the digit-look-alike Cyrillic "з") must be
+  # left intact.
+  test "sanitize an offending label that is a substring of a benign sibling label" do
+    assert_sanitize "магазин.xn--g1a.example.com", "магазин.з.example.com"
+  end
+
+  # A spoofed label repeated in different casing must be sanitized at every
+  # position, each occurrence punycoded from its own spelling.
+  test "sanitize a confusable label repeated with different casing across labels" do
+    assert_sanitize "xn--pple-43d.xn--pple-43d.example.com", "Аpple.аpple.example.com"
+  end
+
   private
     def assert_sanitize(sanitized, domain)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::Idn.sanitize(domain)

--- a/test/sanitizer/idn_test.rb
+++ b/test/sanitizer/idn_test.rb
@@ -55,6 +55,13 @@ class HomographicSpoofing::Sanitizer::IdnTest < ActiveSupport::TestCase
     assert_sanitize "xn--pple-43d.xn--pple-43d.example.com", "Аpple.аpple.example.com"
   end
 
+  # The offending label's original casing must be recovered at a label boundary,
+  # not from its appearance inside a longer sibling. The standalone "з" is the
+  # attack; the "З" inside "магаЗин" is incidental and must be left intact.
+  test "sanitize an offending label whose lowercase appears inside a sibling label" do
+    assert_sanitize "магаЗин.xn--g1a.example.com", "магаЗин.з.example.com"
+  end
+
   private
     def assert_sanitize(sanitized, domain)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::Idn.sanitize(domain)


### PR DESCRIPTION
## Problem

`Idn#contexts` handed every rule the full subdomain chain — PublicSuffix's `trd`, e.g. `a.b` in `a.b.example.com` — as **one combined label**. But the mixed-script, confusable and digit rules are all *per-label*: a benign sibling label anywhere in the chain would suppress a real attack in another label, and two independently-benign single-script sibling labels would trip a rule against the combined string. `ScriptConfusable` alone was patched for this in #73 by splitting labels locally.

## Fix

Split the `trd` on the same `.` the renderer draws, in `contexts` itself, so **every** rule sees one real label instead of a chain. This subsumes #73's local `ScriptConfusable` split (labels never carry a dot now), so that duplication is reverted with its behaviour unchanged. Within-label true positives are preserved — a homoglyph attack never spans a rendered dot — and only cross-label artifacts are cleared. As a bonus, the sanitizer now punycodes just the offending label instead of the whole chain.

## Per-rule before / after

| Rule | Before (combined chain) | After (per label) | Direction |
|---|---|---|---|
| **Idn::Digits** | benign same-script sibling hides an all-look-alike digit label → **false negative** | each label scanned; the digit-look-alike label is caught | gains a true positive |
| **MixedScripts** | single-script siblings of different scripts look "mixed" → **false positive** | each single-script label passes | loses a false positive |
| **MixedDigits** | siblings using different digit systems trip the cross-label count → **false positive** | each single-digit-script label passes | loses a false positive |
| **ScriptSpecific** (latin_spoof) | non-ASCII-Latin label beside a non-Latin sibling → **false positive** | applied within a label only, per the rule's own intent | loses a false positive |
| **ScriptConfusable** | already per-label via #73's local split | shared split feeds single labels; #73's split reverted | unchanged (dedup) |
| InvisibleCharacters / DangerousPattern | `^`/`\z`-anchored patterns saw the whole chain | anchor per label (removes a latent cross-label FN) | unchanged on corpus |
| DisallowedCharacters / UnsafeMiddleDot / DeviationCharacters | combined label, `.`-inclusive char set | per-label; `detected?` identical, label attribution sharper | unchanged verdict |

## Corpus diff (verdict changes)

Differential run of `Idn.detections` over the full existing test corpus (178 asserted domains) plus targeted probes, before vs after:

- **0** verdict flips among the 178 existing test-asserted domains. 7 multi-label confusable domains from #73 keep `det=true` (`reason: script_confusable`) but now report the precise offending label and drop a spurious sibling `mixed_scripts` finding.
- **4** verdict flips on new probe inputs, one per defect:

| Input | Before | After | Defect fixed |
|---|---|---|---|
| `мир.з.example.com` | safe | **attack** `digits` (`з`) | Idn::Digits FN |
| `عربي٢.فارسي۲.example.com` | attack `mixed_digits` | **safe** | MixedDigits FP |
| `shop.москва.example.com` | attack `mixed_scripts` | **safe** | MixedScripts FP |
| `café.мир.example.com` | attack `mixed_scripts`+`script_specific` | **safe** | MixedScripts + ScriptSpecific FP |

Within-label true positives stay caught (`shop.pаypal.example.com` → `mixed_scripts`; `عربي٢۲.example.com` → `mixed_digits`; `рау.example.com` → `script_confusable`). Legit multi-label and ccTLD-anchored domains stay safe (`www.shop.example.co.uk`, `рау.почта.ru`, `рау.example.москва`). Degenerate labels (trailing dot, empty middle label, single registrable label) neither raise nor spuriously flag.

## Tests

New `idn_test.rb` block asserts an attack/benign pair per defect through the public detector, plus within-label TP guards, legit multi-label FP guards, and degenerate-label cases. Full suite green on Ruby 3.1–3.4 syntax (`48 runs, 337 assertions, 0 failures`).

## Sanitizer: punycode the offending label as a whole component

Per-label detection hands the sanitizer single labels, which surfaced two flaws in `Sanitizer::Base#punycode`'s substring `gsub` (both raised in review, both fixed with regression tests):

- **Substring corruption** — sanitizing `магазин.з.example.com` replaced the `з` inside the benign sibling `магазин`, mangling it to `магаxn--g1aин`.
- **Duplicate-label under-sanitization (a regression from main)** — `Аpple.аpple.example.com`: detection runs on the lowercased domain, so both labels lowercase to `аpple` and resolved through `original_case` to the same first spelling, leaving the second occurrence unsanitized. On main the whole chain was one detection and every label was punycoded.

`punycode` now replaces the label as a whole `.`/`@`-delimited component; a label that is only a substring of a component (a display name with spaces) falls back to the existing substring replacement, so email name/local-part sanitization is unchanged.

Matching is **case-exact**, not case-folded. To make that correct for a spoof repeated in different casing, the detector carries each split label's **occurrence index** (its position among identical labels, left to right) and `original_case` returns the casing of that occurrence — so `Аpple` and `аpple` are reported distinctly and each is punycoded at its position. Case-exact matching also keeps a domain detection from reaching across the `@` to a benign case-variant local part: `РАУ@рау.com` sanitizes to `РАУ@xn--80a5ak.com`, leaving the mailbox intact. (Regexp `/i` folding was rejected — it over-matches unrelated pairs like `ſ/s` and `ᴡ/W`, which #74's uppercase tests guard.)

Fixes `sanitize_idn` and `sanitize_email_address` alike; all of #74's uppercase/whitespace/special-case sanitizer tests continue to pass.

## Known follow-up (out of scope here)

Per-label domain detection makes one pre-existing limitation of the *email* sanitizer reachable: `Sanitizer::Base` replaces matching components across the whole address (by design — `tᴡitter@tᴡitter.com` punycodes both sides), so a domain-label detection whose text exactly equals a benign local part the local detector accepted — e.g. `з@мир.з.example.com` — punycodes the mailbox too. `sanitize_idn` (this PR's subject) is unaffected; only `sanitize_email_address` with a mailbox identical to a spoofed domain label. The correct fix is part/span-aware detections (each `Detection` carrying the address part and span it came from), which spans the shared `Detection` struct, `Sanitizer::Base`, and the `EmailAddress` detector family and touches its name/local formatting guards — a dedicated follow-up rather than widening this detector-scoped change.
