### PR TITLE
Scope punycode replacement to the address part the detection came from

### DIFF
--- a/lib/homographic_spoofing/detector/detection.rb
+++ b/lib/homographic_spoofing/detector/detection.rb
@@ -1,2 +1,10 @@
-class HomographicSpoofing::Detector::Detection < Struct.new(:reason, :label)
+# `span` is the [offset, length] of the address component the detection came
+# from, in characters, within the field — so the sanitizer punycodes the
+# offending label only inside that component and never rewrites a matching label
+# in a sibling component (a local part equal to a spoofed domain label, say). It
+# is derived from the parsed address, not by re-scanning the raw string for an
+# "@", which trailing CFWS comments or a display name can carry spuriously. It
+# is nil for detectors that run against a standalone string (a bare IDN or
+# quoted string), where the whole field is the one component.
+class HomographicSpoofing::Detector::Detection < Struct.new(:reason, :label, :span)
 end

--- a/lib/homographic_spoofing/detector/email_address.rb
+++ b/lib/homographic_spoofing/detector/email_address.rb
@@ -17,10 +17,11 @@ class HomographicSpoofing::Detector::EmailAddress
 
   def detections
     mail_address = mail_address_wrap(email_address)
+    spans = component_spans(mail_address)
     [].tap do |result|
-      result.concat detector_for(part: mail_address.name,   type: "quoted_string").detections if mail_address.name
-      result.concat detector_for(part: mail_address.local,  type: "local").detections if mail_address.local
-      result.concat detector_for(part: mail_address.domain, type: "idn").detections if mail_address.domain
+      result.concat detections_for(text: mail_address.name,   type: "quoted_string", span: spans[:name])
+      result.concat detections_for(text: mail_address.local,  type: "local",         span: spans[:local])
+      result.concat detections_for(text: mail_address.domain, type: "idn",           span: spans[:domain])
     end
   rescue Mail::Field::FieldError
     # Do not analyse invalid email addresses.
@@ -30,8 +31,99 @@ class HomographicSpoofing::Detector::EmailAddress
   private
     attr_reader :email_address
 
-    def detector_for(type:, part:)
-      "HomographicSpoofing::Detector::#{type.camelize}".constantize.new(part)
+    # Tag each detection with the [offset, length] of the component it came from
+    # so the sanitizer scopes the punycode replacement to that component alone —
+    # a domain-label spoof never rewrites a benign local part that merely equals
+    # the same string.
+    def detections_for(text:, type:, span:)
+      if text
+        detector_for(type:, text:).detections.each { |detection| detection.span = span }
+      else
+        []
+      end
+    end
+
+    def detector_for(type:, text:)
+      "HomographicSpoofing::Detector::#{type.camelize}".constantize.new(text)
+    end
+
+    # Derive each component's [offset, length] span from parser token boundaries,
+    # not by searching the raw field for the stripped parts. The addr-spec built
+    # from the parser's *raw* local and domain — which keep the CFWS the stripped
+    # forms drop — is by construction a contiguous substring of the field, so its
+    # offset pins the mailbox and host spans exactly even when a comment or stray
+    # whitespace sits inside the address. The offset prefers the angle-address, so
+    # a display name that repeats the addr-spec cannot divert the recipient's
+    # replacement onto the name. Only the display name — never the recipient — is
+    # still located by text, since a mislocated name only misplaces a cosmetic
+    # fix. When the field is not a raw string (a Mail::Address handed straight to a
+    # detection query) there is nothing to sanitize, so spans are left nil.
+    def component_spans(mail_address)
+      local, domain, name = mail_address.local, mail_address.domain, mail_address.name
+      return {} unless email_address.is_a?(String)
+
+      raw_local, raw_domain = raw_addr_spec_parts
+      addr = "#{raw_local}@#{raw_domain}" if raw_local && raw_domain
+      at = addr_offset(addr) if addr
+
+      if at
+        { name:   (locate(name, avoid: [ at, addr.length ]) if name),
+          local:  ([ at, raw_local.length ] if local),
+          domain: ([ at + raw_local.length + 1, raw_domain.length ] if domain) }
+      else
+        structural_spans(local, domain, name)
+      end
+    end
+
+    # The raw local and domain of the addr-spec as they appear in the field, CFWS
+    # included, from the address parser — or nils when it cannot supply them.
+    def raw_addr_spec_parts
+      parsed = Mail::Parsers::AddressListsParser.parse(email_address).addresses.first
+      [ parsed&.local, parsed&.domain ]
+    rescue StandardError
+      [ nil, nil ]
+    end
+
+    # The addr-spec's offset in the field, preferring the angle-address
+    # "<local@domain>" — a quoted display name that repeats the addr-spec anchors
+    # there otherwise, leaving the real recipient unsanitized. Fall back to the
+    # first bare occurrence.
+    def addr_offset(addr)
+      bracketed = email_address.index("<#{addr}>")
+      bracketed ? bracketed + 1 : email_address.index(addr)
+    end
+
+    # Fallback when the parser yields no raw addr-spec: bound the components by the
+    # structural delimiters instead. The addr-spec sits between the angle brackets
+    # when present (split at its "@"), otherwise leads the field at the first "@".
+    def structural_spans(local, domain, name)
+      lt = email_address.rindex("<")
+      gt = email_address.index(">", lt) if lt
+      at = email_address.index("@", lt || 0)
+
+      if lt && gt && at && at < gt
+        { name:   (locate(name, avoid: [ lt, gt - lt + 1 ]) if name),
+          local:  ([ lt + 1, at - lt - 1 ] if local),
+          domain: ([ at + 1, gt - at - 1 ] if domain) }
+      elsif at
+        { name:   (locate(name) if name),
+          local:  ([ 0, at ] if local),
+          domain: (locate(domain, from: at + 1) if domain) }
+      else
+        {}
+      end
+    end
+
+    # The first occurrence of `text` in the field at or after `from` whose span
+    # does not fall inside `avoid` (the angle-address, when locating a display
+    # name that shares a spelling with the mailbox or host).
+    def locate(text, from: 0, avoid: nil)
+      while (at = email_address.index(text, from))
+        span = [ at, text.length ]
+        return span unless avoid && at >= avoid[0] && at < avoid[0] + avoid[1]
+        from = at + 1
+      end
+      nil
     end
 
     def mail_address_wrap(email_address)

--- a/lib/homographic_spoofing/sanitizer/base.rb
+++ b/lib/homographic_spoofing/sanitizer/base.rb
@@ -11,31 +11,44 @@ class HomographicSpoofing::Sanitizer::Base
 
   def sanitize
     result = field.dup
-    detector_class.new(field).detections.each do |detection|
-      log(detection.reason, detection.label)
-      result = punycode(result, detection.label)
-    end
-    result
+    detections = detector_class.new(field).detections
+    detections.each { |detection| log(detection.reason, detection.label) }
+    apply(result, detections)
   end
 
   private
     attr_reader :field
 
-    # Detections are per label. When the label is a complete component of the
-    # field — a whole domain label or local part, delimited by "." or "@" —
-    # punycode it as that component so an offending label is never replaced as a
-    # substring of a benign sibling (e.g. the Cyrillic digit-look-alike "з" that
-    # also sits inside "магазин"). Matching is case-exact: the detector reports
-    # each label in the casing of its own position, so a spoof repeated in
-    # different casing yields a detection per occurrence, and a benign
-    # case-variant on the other side of the "@" is left alone. A label that is
-    # only a substring of a component (a display name carrying spaces) has no
-    # whole component to match and falls back to the exact substring replacement.
-    def punycode(source, label)
-      if source.split(/[.@]/).any? { |component| component.strip == label }
-        source.split(/([.@])/).map { |component| component.strip == label ? component.sub(label, Dnsruby::Name.punycode(label)) : component }.join
+    # Punycode each offending label only within the component it came from. A
+    # spanned detection carries the [offset, length] of its component, so a
+    # domain-label spoof is confined to the domain and never rewrites a benign
+    # local part that merely equals the same string — this is what keeps
+    # "з@мир.з.example.com" punycoding the domain label "з" while leaving the "з"
+    # mailbox intact. Spans are spliced back right-to-left so each edit leaves the
+    # earlier offsets valid. A detection with no span (a bare IDN or quoted
+    # string) spans the whole field and is applied last, over what remains.
+    def apply(result, detections)
+      whole, spanned = detections.partition { |detection| detection.span.nil? }
+      spanned.group_by(&:span).sort_by { |(offset, _length), _group| -offset }.each do |(offset, length), group|
+        segment = result[offset, length]
+        result[offset, length] = group.map(&:label).inject(segment) { |text, label| replace_label(text, label) }
+      end
+      whole.inject(result) { |text, detection| replace_label(text, detection.label) }
+    end
+
+    # Replace `label` where it is a whole "."-delimited component of the region,
+    # so an offending label is never rewritten as a substring of a benign sibling
+    # (the Cyrillic digit-look-alike "з" that also sits inside "магазин"), and
+    # every matching component is punycoded from its own spelling — case-exact,
+    # so a spoof repeated in different casing is handled per occurrence. A label
+    # that is only a substring of a component (a display name carrying spaces)
+    # has no whole component to match and falls back to exact substring
+    # replacement. The surrounding whitespace PublicSuffix strips is preserved.
+    def replace_label(region, label)
+      if region.split(".").any? { |component| component.strip == label }
+        region.split(/(\.)/).map { |component| component.strip == label ? component.sub(label, Dnsruby::Name.punycode(label)) : component }.join
       else
-        source.gsub(label) { Dnsruby::Name.punycode(label) }
+        region.gsub(label) { Dnsruby::Name.punycode(label) }
       end
     end
 

--- a/test/sanitizer/email_address_test.rb
+++ b/test/sanitizer/email_address_test.rb
@@ -75,6 +75,63 @@ class HomographicSpoofing::Sanitizer::EmailAddressTest < ActiveSupport::TestCase
     assert_sanitize "РАУ@xn--80a5ak.com", "РАУ@рау.com"
   end
 
+  # A domain-label spoof is punycoded only within the domain: a benign local
+  # part that merely equals the offending label is an independent mailbox and
+  # must be left intact. Per-label domain detection makes this reachable — the
+  # digit-look-alike Cyrillic "з" is a domain spoof, but a plain "з" mailbox is
+  # not — so the replacement must not bleed across the "@".
+  test "domain-label spoof leaves a matching benign local part intact" do
+    assert_sanitize "з@мир.xn--g1a.example.com", "з@мир.з.example.com"
+  end
+
+  test "domain-label spoof leaves a plain-ASCII local part untouched" do
+    assert_sanitize "jacopo@мир.xn--g1a.example.com", "jacopo@мир.з.example.com"
+  end
+
+  # Both sides genuinely spoofed: the confusable "tᴡitter" is detected in the
+  # local part and in the domain, so both are punycoded. Part-scoping narrows
+  # where a replacement lands; it must not drop a real detection on either side.
+  test "spoof present in both local part and domain punycodes both" do
+    assert_sanitize "xn--titter-345b@xn--titter-345b.com", "tᴡitter@tᴡitter.com"
+  end
+
+  # The component span is derived from the parsed addr-spec, not from the last
+  # raw "@": a trailing RFC comment carrying its own "@" must not move the domain
+  # region off the real host and leave the spoof unsanitized.
+  test "spoofed domain is sanitized despite a trailing comment containing an at-sign" do
+    assert_sanitize "user@xn--titter-345b.com (contact@work)", "user@tᴡitter.com (contact@work)"
+  end
+
+  # When a quoted display name repeats the addr-spec, the domain span must anchor
+  # on the angle-address — the real recipient — not the first textual occurrence
+  # inside the name, or the spoofed recipient domain is left unsanitized.
+  test "spoofed recipient domain is sanitized when the display name repeats the addr-spec" do
+    assert_sanitize "\"user@tᴡitter.com\" <user@xn--titter-345b.com>", "\"user@tᴡitter.com\" <user@tᴡitter.com>"
+  end
+
+  # The recipient is bounded by the addr-spec's parser-token span, not by
+  # searching for the parsed text, so CFWS around the "@" (which stops the
+  # addr-spec from occurring contiguously) plus a display name that repeats it
+  # cannot divert the replacement onto the name and leave the real recipient
+  # domain spoofed.
+  test "spoofed recipient domain is sanitized despite whitespace before the at-sign" do
+    assert_sanitize "\"bob@tᴡitter.com\" <bob @xn--titter-345b.com>", "\"bob@tᴡitter.com\" <bob @tᴡitter.com>"
+  end
+
+  # A leading comment carrying its own "@" must not be mistaken for the addr-spec
+  # separator; the real mailbox after it is still sanitized.
+  test "spoofed mailbox is sanitized despite a leading comment containing an at-sign" do
+    assert_sanitize "(contact@work) xn--titter-345b@example.com", "(contact@work) tᴡitter@example.com"
+  end
+
+  # A comment inside the domain keeps the parsed domain from occurring
+  # contiguously; the domain span must still stay on the domain so the spoofed
+  # label is punycoded without rewriting the benign mailbox that equals it — the
+  # original bug must not reappear through a CFWS domain.
+  test "domain-label spoof through a domain comment leaves the matching mailbox intact" do
+    assert_sanitize "з@xn--g1a(comment).example.com", "з@з(comment).example.com"
+  end
+
   private
     def assert_sanitize(sanitized, email_address)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::EmailAddress.sanitize(email_address)

--- a/test/sanitizer/idn_test.rb
+++ b/test/sanitizer/idn_test.rb
@@ -62,6 +62,14 @@ class HomographicSpoofing::Sanitizer::IdnTest < ActiveSupport::TestCase
     assert_sanitize "магаЗин.xn--g1a.example.com", "магаЗин.з.example.com"
   end
 
+  # The email-address path scopes each replacement to the component it came
+  # from; the bare-IDN path has a single component — the whole domain — so
+  # part-scoping is a no-op here and this stays identical: the offending label
+  # "з" is punycoded, its benign sibling "мир" untouched.
+  test "part-scoping does not change bare-IDN sanitizing" do
+    assert_sanitize "мир.xn--g1a.example.com", "мир.з.example.com"
+  end
+
   private
     def assert_sanitize(sanitized, domain)
       assert_equal sanitized, HomographicSpoofing::Sanitizer::Idn.sanitize(domain)


### PR DESCRIPTION
> Stacked on #76 — merge #76 first. This branch is based on `perlabel-mixed-scripts`, so its diff and green CI include #76's changes until that lands.

## The bug

`sanitize_email_address` replaced **every** address component that matched a `Detection`, across the whole address. So a benign local part that merely equals a spoofed domain label was punycoded too:

```ruby
HomographicSpoofing.sanitize_email_address("з@мир.з.example.com")
# before: "xn--g1a@мир.xn--g1a.example.com"  ← the "з" MAILBOX got rewritten
# after:  "з@мир.xn--g1a.example.com"        ← only the domain label "з" is punycoded
```

The domain label `з` (Cyrillic, a digit-look-alike for `3`) is a genuine spoof; the `з` **mailbox** is an independent, benign local part and must be left intact. This is pre-existing by-design `Sanitizer::Base` behavior (cf. `tᴡitter@tᴡitter.com` punycoding both sides) that per-label domain detection in #76 newly made reachable with a benign mailbox. It was raised as a Codex P2 on #76 and deferred here.

Cosmetic and email-address-only: no detection is weakened and no spoof is missed — only the *scope* of each replacement changes. `sanitize_idn` (domain-only) is unaffected.

## The fix

Make detections carry the span of the component they came from, and replace only within it.

- `Detection` now carries `span` — the `[offset, length]` of its address component within the field. It is `nil` for detectors that run against a standalone string (bare IDN, quoted string), where the whole field is the one component.
- `Detector::EmailAddress` derives those spans from **parser token boundaries**, not by searching the raw field for the stripped parts. The addr-spec built from the parser's *raw* local and domain — which keep the CFWS the stripped forms drop — is a contiguous substring of the field, so its offset pins the mailbox and host exactly even when a comment or stray whitespace sits inside the address; it is located inside the structural angle-address — `<` and `>` outside every quoted string and comment, searched within rather than matched as `<addr>` so an obsolete route (`<@relay:local@domain>`) still resolves — so a display name or comment that repeats the addr-spec, bare or bracketed, cannot divert the recipient's replacement onto itself. The display name and a bare addr-spec are located outside comments, so leading CFWS that repeats either does not take its replacement. The structural scan follows RFC 5322: quoted strings, domain literals and (nested) comments are enclosures with backslash escapes, and inside a comment only parentheses have structure. Only the display name (never the recipient) is still located by text, since a mislocated name only misplaces a cosmetic fix. A structural angle-bracket / first-`@` fallback covers the rare case the parser yields no raw addr-spec.
- `Sanitizer::Base` punycodes each label only within its span, splicing right-to-left so earlier offsets stay valid. Within a span it keeps #76's whole-component matching (so multi-label domains and display names still work), comparing each component with its CFWS set aside and splitting labels on dots outside comments, so a comment attached to a label (`з(comment)`, `з(note.example)`) still matches as a whole label and never sends the replacement into a sibling. A display name the parser takes from a trailing comment keeps its span in that comment.

The fix is "replace only within the component the detection actually came from," **not** "only ever touch the domain." A spoof genuinely present on both sides still reports a detection per component, so both are punycoded:

```ruby
sanitize_email_address("tᴡitter@tᴡitter.com") # => "xn--titter-345b@xn--titter-345b.com"
```

## Review

Copilot and Codex raised a sequence of same-class findings — the recipient span being diverted by a trailing RFC comment's `@`, a quoted display name that repeats the addr-spec, CFWS around the `@`, a leading comment's `@`, and a comment inside the domain. Rather than patch the string search once per variation, the span source was reworked to parser token boundaries, which closes the class: the recipient addr-spec is never located by ambiguous text search. Each reported case has a regression test.

## Tests

Added, asserting actual sanitized output:

- domain-label spoof leaves a matching benign local part intact (`з@мир.з.example.com`)
- domain-label spoof leaves a plain-ASCII local part untouched (`jacopo@мир.з.example.com`)
- spoof present on both sides punycodes both (`tᴡitter@tᴡitter.com`)
- spoofed domain sanitized despite a trailing comment containing `@` (`user@tᴡitter.com (contact@work)`)
- spoofed recipient domain sanitized when the display name repeats the addr-spec (`"user@tᴡitter.com" <user@tᴡitter.com>`)
- spoofed recipient domain sanitized when the display name or a comment contains the *bracketed* addr-spec, including behind an escaped quote (`"<user@tᴡitter.com>" <user@tᴡitter.com>`)
- spoofed recipient domain sanitized behind an obsolete route when the display name repeats the addr-spec (`"user@tᴡitter.com" <@example.org:user@tᴡitter.com>`)
- spoofed display name sanitized when a leading comment repeats it (`(Jacopo\u202e) "Jacopo\u202e" <user@example.com>`)
- spoofed recipient domain sanitized when a comment carries an unmatched quote and repeats the addr-spec (`(call "user@tᴡitter.com) Name <user@tᴡitter.com>`)
- spoofed recipient domain sanitized behind a route whose domain literal contains `>` (`<@[relay>node]:user@tᴡitter.com>`)
- spoofed bare recipient domain sanitized when a leading comment repeats the addr-spec (`(user@tᴡitter.com) user@tᴡitter.com`)
- spoofed recipient domain sanitized when a comment inside the angle-address repeats the addr-spec (`<(user@tᴡitter.com) @example.org:user@tᴡitter.com>`)
- domain-label spoof with an attached comment leaves a benign sibling containing the label intact (`user@магазин.з(comment).example.com`)
- domain-label spoof with an attached dotted comment leaves a benign sibling intact (`user@магазин.з(note.example).example.com`)
- spoofed display name from a trailing comment is sanitized without rewriting the matching mailbox (`á́́@example.com (á́́)`)
- spoofed recipient domain sanitized despite whitespace before the `@` (`"bob@tᴡitter.com" <bob @tᴡitter.com>`)
- spoofed mailbox sanitized despite a leading comment containing `@` (`(contact@work) tᴡitter@example.com`)
- domain-label spoof through a domain comment leaves the matching mailbox intact (`з@з(comment).example.com`)
- `sanitize_idn` unchanged (`мир.з.example.com` → `мир.xn--g1a.example.com`)

Full suite green locally on Ruby 3.4.5 and 3.2.2 (CI matrix is 3.1–3.4): 75 runs, 364 assertions, 0 failures.





